### PR TITLE
Bugfix: null pointer dereference

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ rad-unnumbered is a very light weight ipv6 RA server that dynamically detects an
 - it matches tap interface name by regex, to handle only matching interfaces (tap.*_0), can be configured through command line
 - if tap matches regex AND has at least one route pointing to it, it will send RAs advertising a default route on that interface
 - if tap matches regex AND also has a host route (aka /128) pointing there, it will pick the first host route in the list and advertise that as a /64 prefix so clients can auto configure themselfs with a slaac IP.
-  rad-unnumbered assumes the host route found is actually matching the SLAAC ip for the VMs assigned mac address - but rad-unnumbered has no knowledge of this mac to verify
+
+
+### NOTE:
+- rad-unnumbered *assumes* the host route found is actually matching the SLAAC ip for the VMs assigned mac address - but rad-unnumbered has no knowledge of this mac to verify
 
 
 ### usage:

--- a/main.go
+++ b/main.go
@@ -141,6 +141,14 @@ func main() {
 				continue
 			}
 
+			if link.Attrs().Statistics == nil {
+				ll.WithFields(ll.Fields{"Interface": ifName}).Infof(
+					"Netlink fired: %v, admin: %v, OperState: %v",
+					ifName,
+					link.Attrs().Flags&net.FlagUp,
+					tapState,
+				)
+			}
 			ll.WithFields(ll.Fields{"Interface": ifName}).Tracef(
 				"Netlink fired: %v, admin: %v, OperState: %v",
 				ifName,

--- a/main.go
+++ b/main.go
@@ -147,14 +147,6 @@ func main() {
 				continue
 			}
 
-			if linkAttrs.Statistics == nil {
-				ll.WithFields(ll.Fields{"Interface": ifName}).Infof(
-					"Netlink fired: %v, admin: %v, OperState: %v",
-					ifName,
-					linkAttrs.Flags&net.FlagUp,
-					tapState,
-				)
-			}
 			ll.WithFields(ll.Fields{"Interface": ifName}).Tracef(
 				"Netlink fired: %v, admin: %v, OperState: %v",
 				ifName,

--- a/main.go
+++ b/main.go
@@ -142,12 +142,10 @@ func main() {
 			}
 
 			ll.WithFields(ll.Fields{"Interface": ifName}).Tracef(
-				"Netlink fired: %v, admin: %v, OperState: %v, Rx/Tx: %v/%v",
+				"Netlink fired: %v, admin: %v, OperState: %v",
 				ifName,
 				link.Attrs().Flags&net.FlagUp,
 				tapState,
-				link.Attrs().Statistics.RxPackets,
-				link.Attrs().Statistics.TxPackets,
 			)
 
 			tapExists := e.Exists(link.Attrs().Index)

--- a/ra.go
+++ b/ra.go
@@ -61,7 +61,7 @@ func (t Tap) sendLoop(ctx context.Context, c *ndp.Conn) error {
 		case <-ctx.Done():
 			ll.WithFields(ll.Fields{"Interface": t.Ifi.Name}).
 				Debugf("%s sender closed, sent: %d advertisements", t.Ifi.Name, count)
-			return nil
+			return ctx.Err()
 		// Trigger RA at regular intervals or on demand.
 		case <-time.After(*flagInterval):
 		case <-t.rs:
@@ -77,7 +77,7 @@ func (t Tap) receiveLoop(ctx context.Context, c *ndp.Conn) error {
 		case <-ctx.Done():
 			ll.WithFields(ll.Fields{"Interface": t.Ifi.Name}).
 				Debugf("%s listener closed, received: %d solicits", t.Ifi.Name, count)
-			return nil
+			return ctx.Err()
 		default:
 		}
 

--- a/routes.go
+++ b/routes.go
@@ -39,6 +39,16 @@ func getHostRoutesIpv6(ifIdx int) ([]*net.IPNet, []*net.IPNet, error) {
 	var hr []*net.IPNet
 	var sr []*net.IPNet
 	for _, d := range ro {
+		match := false
+		for _, e := range exclude {
+			if e.Contains(d.Dst.IP) {
+				match = true
+			}
+		}
+		if match {
+			continue
+		}
+
 		m, l := d.Dst.Mask.Size()
 		if m == 128 && l == 128 {
 			hr = append(hr, d.Dst)

--- a/routes.go
+++ b/routes.go
@@ -12,8 +12,10 @@ import (
 // there are certain aspects not fulfilled. (i.e. link local may not yet be assinged etc
 // it will also help on edge cases where the interface is not yet fully provisioned even though up
 func linkReady(l *netlink.LinkAttrs) bool {
-	if l.OperState == 6 && l.Flags&net.FlagUp == net.FlagUp && l.Statistics.TxPackets > 0 {
-		return true
+	if l.OperState == 6 && l.Flags&net.FlagUp == net.FlagUp {
+		if l.Statistics != nil && l.Statistics.TxPackets > 0 {
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
certain edge cases netlink messages don't include all information causing a nil pointer panic.

it also piggybacks a small feature to exclude certain subnets from being advertised