### PR TITLE
fix go.mod go version formatting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/linode/rad-unnumbered
 
-go 1.23.1
+go 1.23
 
 require (
 	github.com/mdlayher/ndp v0.0.0-20210831201139-f982b8766fb5


### PR DESCRIPTION
Just fix this error that happened during build.

```
go: errors parsing go.mod:
/data/go.mod:3: invalid go version '1.23.1': must match format 1.23
```