### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ rad-unnumbered is a very light weight ipv6 RA server that dynamically detects an
 - it finds tap interfaces dynamically through netlink push msg as they are created/destroyed
 - it matches tap interface name by regex, to handle only matching interfaces (tap.*_0), can be configured through command line
 - if tap matches regex AND has at least one route pointing to it, it will send RAs advertising a default route on that interface
-- if tap matches regex AND also has a host route (aka /128) pointing there, it will pick the first host route in the list and advertise that as a /64 prefix so clients can auto configure themselfs with a slaac IP.
+- if tap matches regex AND also has a host route (aka /128) pointing there, it will pick the first host route in the list and advertise that as a /64 prefix so clients can auto configure themselves with a slaac IP.
 
 
 ### NOTE:

--- a/engine.go
+++ b/engine.go
@@ -30,7 +30,7 @@ func NewEngine(regex string) (*Engine, error) {
 	}, nil
 }
 
-// Qualifies checks if interface qulalifies, aka matches the regex for taps to be handled
+// Qualifies checks if interface qualifies, aka matches the regex for taps to be handled
 func (e *Engine) Qualifies(ifName string) bool {
 	return e.regex.Match([]byte(ifName))
 }
@@ -69,7 +69,7 @@ func (e *Engine) Add(ifIdx int) {
 	}()
 }
 
-// Get returns a lookedup Tap interface thread safe
+// Get returns a looked up Tap interface thread safe
 func (e *Engine) Get(ifIdx int) Tap {
 	e.lock.RLock()
 	defer e.lock.RUnlock()

--- a/ra.go
+++ b/ra.go
@@ -21,7 +21,7 @@ func (t Tap) doRA(c *ndp.Conn) error {
 	return eg.Wait()
 }
 
-// tiggers RouterAdvertisements every Interval duration or when a RouterSolicit was received on the interface
+// triggers RouterAdvertisements every Interval duration or when a RouterSolicit was received on the interface
 func (t Tap) sendLoop(ctx context.Context, c *ndp.Conn) error {
 	var options = []ndp.Option{
 		&ndp.LinkLayerAddress{
@@ -48,7 +48,7 @@ func (t Tap) sendLoop(ctx context.Context, c *ndp.Conn) error {
 		Options:                   options,
 	}
 
-	// Send messages until cancelation or error.
+	// Send messages until cancellation or error.
 	count := 0
 	for {
 		ll.WithFields(ll.Fields{"Interface": t.Ifi.Name}).Debugf("%s sent RA prefix %s", t.Ifi.Name, t.Prefix)
@@ -95,7 +95,7 @@ func (t Tap) receiveLoop(ctx context.Context, c *ndp.Conn) error {
 	}
 }
 
-// receiveRS reads RouterSolicitsts but tries to keep it brief
+// receiveRS reads RouterSolicits but tries to keep it brief
 func receiveRS(c *ndp.Conn) (ndp.Message, net.IP, error) {
 	if err := c.SetReadDeadline(time.Now().Add(1 * time.Second)); err != nil {
 		return nil, nil, fmt.Errorf("failed to set deadline: %v", err)

--- a/routes.go
+++ b/routes.go
@@ -9,7 +9,7 @@ import (
 
 // linkReady will return true when its ok to bind the ndp listener to it.
 // it will wait for the TX counter to start incrementing since before thats the case
-// there are certain aspects not fulfilled. (i.e. link local may not yet be assinged etc
+// there are certain aspects not fulfilled. (i.e. link local may not yet be assigned etc
 // it will also help on edge cases where the interface is not yet fully provisioned even though up
 func linkReady(l *netlink.LinkAttrs) bool {
 	if l.OperState == 6 && l.Flags&net.FlagUp == net.FlagUp {

--- a/tap.go
+++ b/tap.go
@@ -38,7 +38,7 @@ func NewTap(idx int) (*Tap, error) {
 
 	if hostRoutes == nil && subnets == nil {
 		return nil, fmt.Errorf(
-			"neither host nor subnet routes to this tap. this may be a private vlan interface, ignoring comletely",
+			"neither host nor subnet routes to this tap. this may be a private vlan interface, ignoring completely",
 		)
 	}
 
@@ -71,7 +71,7 @@ func (t Tap) Listen() error {
 	var err error
 
 	// need this hacky loop since there are occasions where the OS seems to lock the tap for about 15sec (or sometimes longer)
-	// on innitial creation. causing the dialer to fail.
+	// on initial creation. causing the dialer to fail.
 	// this loop checks the context for cancellation but otherwise continues to re-try
 	counter := 0
 	for {


### PR DESCRIPTION
This trivial PR fixes a few typos in comments and strings.